### PR TITLE
Only configure JMX, if the JMXConfigurator is present

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/DefaultLoggingFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/DefaultLoggingFactory.java
@@ -150,22 +150,7 @@ public class DefaultLoggingFactory implements LoggingFactory {
             StatusPrinter.setPrintStream(System.out);
         }
 
-        final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
-        MBEAN_REGISTRATION_LOCK.lock();
-        try {
-            final ObjectName objectName = new ObjectName("io.dropwizard:type=Logging");
-            if (!server.isRegistered(objectName)) {
-                server.registerMBean(new JMXConfigurator(loggerContext,
-                                server,
-                                objectName),
-                        objectName);
-            }
-        } catch (MalformedObjectNameException | InstanceAlreadyExistsException |
-                NotCompliantMBeanException | MBeanRegistrationException e) {
-            throw new RuntimeException(e);
-        } finally {
-            MBEAN_REGISTRATION_LOCK.unlock();
-        }
+        configureJMX();
 
         configureInstrumentation(root, metricRegistry);
     }
@@ -241,6 +226,30 @@ public class DefaultLoggingFactory implements LoggingFactory {
         appender.setContext(loggerContext);
         appender.start();
         root.addAppender(appender);
+    }
+
+    private void configureJMX() {
+        try {
+            Class.forName("ch.qos.logback.classic.jmx.JMXConfigurator");
+        } catch (ClassNotFoundException e) {
+            return;
+        }
+        final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        MBEAN_REGISTRATION_LOCK.lock();
+        try {
+            final ObjectName objectName = new ObjectName("io.dropwizard:type=Logging");
+            if (!server.isRegistered(objectName)) {
+                server.registerMBean(new JMXConfigurator(loggerContext,
+                        server,
+                        objectName),
+                    objectName);
+            }
+        } catch (MalformedObjectNameException | InstanceAlreadyExistsException |
+                 NotCompliantMBeanException | MBeanRegistrationException e) {
+            throw new RuntimeException(e);
+        } finally {
+            MBEAN_REGISTRATION_LOCK.unlock();
+        }
     }
 
     private Logger configureLoggers(String name) {


### PR DESCRIPTION
Ports https://github.com/dropwizard/dropwizard/pull/5825 into the 1.3.x branch for our use

This PR allows using SLF4J 2.0.0 and Logback 1.3.0 with Dropwizard 2.1.x.
