### PR TITLE
Fix EofExceptionWriterInterceptor binding

### DIFF
--- a/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java
@@ -541,7 +541,7 @@ public abstract class AbstractServerFactory implements ServerFactory {
             jersey.register(new JacksonBinder(objectMapper));
             jersey.register(new HibernateValidationFeature(validator));
             if (registerDefaultExceptionMappers == null || registerDefaultExceptionMappers) {
-                jersey.register(new ExceptionMapperBinder(detailedJsonProcessingExceptionMapper));
+                jersey.register(new ExceptionMapperBinder(detailedJsonProcessingExceptionMapper, metricRegistry));
             }
             handler.addServlet(new ServletHolder("jersey", jerseyContainer), jersey.getUrlPattern());
         }

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/ExceptionMapperBinder.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/ExceptionMapperBinder.java
@@ -1,6 +1,7 @@
 package io.dropwizard.setup;
 
 import io.dropwizard.jersey.errors.EarlyEofExceptionMapper;
+import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.jersey.errors.EofExceptionWriterInterceptor;
 import io.dropwizard.jersey.errors.IllegalStateExceptionMapper;
 import io.dropwizard.jersey.errors.LoggingExceptionMapper;
@@ -18,9 +19,11 @@ import javax.ws.rs.ext.WriterInterceptor;
  */
 public class ExceptionMapperBinder extends AbstractBinder {
     private final boolean showDetails;
+    private final MetricRegistry metricRegistry;
 
-    public ExceptionMapperBinder(boolean showDetails) {
+    public ExceptionMapperBinder(boolean showDetails, MetricRegistry metricRegistry) {
         this.showDetails = showDetails;
+        this.metricRegistry = metricRegistry;
     }
 
     @Override
@@ -32,7 +35,7 @@ public class ExceptionMapperBinder extends AbstractBinder {
         bind(new EarlyEofExceptionMapper()).to(ExceptionMapper.class);
         bind(new EmptyOptionalExceptionMapper()).to(ExceptionMapper.class);
         bind(new IllegalStateExceptionMapper()).to(ExceptionMapper.class);
-        bind(EofExceptionWriterInterceptor.class).to(WriterInterceptor.class);
+        bind(new EofExceptionWriterInterceptor(metricRegistry)).to(WriterInterceptor.class);
     }
 
     public boolean isShowDetails() {

--- a/dropwizard-core/src/main/java/io/dropwizard/setup/ExceptionMapperBinder.java
+++ b/dropwizard-core/src/main/java/io/dropwizard/setup/ExceptionMapperBinder.java
@@ -1,7 +1,7 @@
 package io.dropwizard.setup;
 
-import io.dropwizard.jersey.errors.EarlyEofExceptionMapper;
 import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.jersey.errors.EarlyEofExceptionMapper;
 import io.dropwizard.jersey.errors.EofExceptionWriterInterceptor;
 import io.dropwizard.jersey.errors.IllegalStateExceptionMapper;
 import io.dropwizard.jersey.errors.LoggingExceptionMapper;

--- a/dropwizard-testing/src/main/java/io/dropwizard/testing/common/DropwizardTestResourceConfig.java
+++ b/dropwizard-testing/src/main/java/io/dropwizard/testing/common/DropwizardTestResourceConfig.java
@@ -33,7 +33,7 @@ class DropwizardTestResourceConfig extends DropwizardResourceConfig {
         super(true, configuration.metricRegistry);
 
         if (configuration.registerDefaultExceptionMappers) {
-            register(new ExceptionMapperBinder(false));
+            register(new ExceptionMapperBinder(false, configuration.metricRegistry));
         }
         for (Class<?> provider : configuration.providers) {
             register(provider);


### PR DESCRIPTION
###### Problem:

`EofExceptionWriterInterceptor` is registered via a class-based binding, which requires the `MetricRegistry` dependency to be resolved through constructor injection. `MetricRegistry` may not be available when the binder is processed. This causes the binding to silently fail so the interceptor never registers, and `EofException`s from client disconnects propagate as ERROR-level logs instead of being caught silently.

###### Solution:

Pre-instantiate `EofExceptionWriterInterceptor` with an explicit `MetricRegistry`, consistent with every other binding in `ExceptionMapperBinder`.

###### Result:

`EofExceptionWriterInterceptor` registers in the Jersey interceptor chain as intended. Client disconnects during response writing are caught and logged at DEBUG instead of propagating as ERROR-level `MappableException`s.